### PR TITLE
Fix: Buffer overflow at vue.jar by using maxBuffer in Chunkify

### DIFF
--- a/lib/chunkify.js
+++ b/lib/chunkify.js
@@ -1,14 +1,29 @@
 'use strict';
 
-module.exports = function( files, maxChars ) {
+module.exports = function( files, maxChars, maxBuffer ) {
+  var fs = require( 'fs' );
   var filesChunk = [];
   var chunk = '';
+  var chunkLen = 0;
+  var stats;
 
   for ( var f = 0, len = files.length; f < len; f++ ) {
-    if ( chunk.length + ( files[ f ].length + 1 ) > maxChars ) {
+    stats = undefined;
+
+    if ( fs.existsSync( files[ f ] ) ) {
+      stats = fs.statSync( files[ f ] );
+    }
+
+    if ( chunk.length + ( files[ f ].length + 1 ) > maxChars || ( stats && ( chunkLen + stats.size + 1 > maxBuffer ) ) ) {
       filesChunk.push( chunk );
       chunk = '';
+      chunkLen = 0;
     }
+
+    if ( stats ) {
+      chunkLen += stats.size;
+    }
+
     chunk += '"' + files[ f ] + '" ';
   }
   filesChunk.push( chunk );

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -80,7 +80,8 @@ module.exports = function( config, done ) {
     }
 
     var files = config.files.map( path.normalize );
-    async.mapSeries( chunkify( files, maxChars ), function( chunk, cb ) {
+    var chunks = chunkify( files, maxChars, maxBuffer );
+    async.mapSeries( chunks, function( chunk, cb ) {
 
       exec( cmd( java, chunk, config.noLangDetect ), {
         'maxBuffer': maxBuffer


### PR DESCRIPTION
when multiple files are inputed to vnu.jar, which overall side exceeding more than 20BM (with #24 ), grunt task fails with `>> Error: stderr maxBuffer exceeded.`

To fix this, I'm using maxBuffer also while chunkifying all input files to grunt task.